### PR TITLE
Added __connect__ call to session_payouts

### DIFF
--- a/expecon/templates/session_payouts.html
+++ b/expecon/templates/session_payouts.html
@@ -85,6 +85,8 @@
 				update_payouts(msg.Sender);
 			});
 
+			r.__connect__();
+
 		}]);
 	</script>
 </head>


### PR DESCRIPTION
session_payouts uses RedwoodCore, which does not automatically call **connect**, so no message handlers are called. This fixes this problem, but a (possibly) better way to fix this would be to expose this function and make experiment code manually call connect.
