### PR TITLE
Fixed broken login URL

### DIFF
--- a/redwood/settings.py
+++ b/redwood/settings.py
@@ -7,7 +7,7 @@ BASE_DIR = os.path.dirname(os.path.dirname(__file__))
 app_config = json.load(open(os.path.join(BASE_DIR, 'apache/config.json')))
 
 URL_PREFIX = app_config['URL_PREFIX']
-LOGIN_URL = URL_PREFIX + '/login/'
+LOGIN_URL = URL_PREFIX + '/admin/login/'
 
 DEBUG = app_config['DEBUG']
 TEMPLATE_DEBUG = DEBUG


### PR DESCRIPTION
When the user is not logged in and tries to access the admin page
for an experiment, the user is redirected to /login/, which doesn't
exist. Before the move to Django 1.7, the user was redirected to the
admin login page. This commit restores that behavior.