### PR TITLE
Removed loading of custom verbatim tag

### DIFF
--- a/expecon/models.py
+++ b/expecon/models.py
@@ -89,7 +89,11 @@ class Page(models.Model):
 				template = 'default_start_page.html'
 			elif self.name == 'Finish':
 				template = 'default_finish_page.html'
-			self.html = loader.render_to_string(template, {'name': self.name, 'loadverbatim': '{% load verbatim %}', 'verbatim': '{% verbatim %}', 'endverbatim': '{% endverbatim %}'})
+			self.html = loader.render_to_string(template, {
+				'name': self.name,
+				'verbatim': '{% verbatim %}',
+				'endverbatim': '{% endverbatim %}'
+			})
 		if self.js.strip() == "":
 			template = 'default_page.js'
 			if self.name == 'Wait':

--- a/expecon/templates/default_admin_page.html
+++ b/expecon/templates/default_admin_page.html
@@ -1,4 +1,4 @@
-{% autoescape off %}{% load verbatim %}<!DOCTYPE HTML>
+{% autoescape off %}<!DOCTYPE HTML>
 <html ng-app="Redwood">
   <head>
 		<title>{{ name }} Admin</title>{% verbatim %}

--- a/expecon/templates/default_admin_page.js
+++ b/expecon/templates/default_admin_page.js
@@ -1,4 +1,4 @@
-{% load verbatim %}{% verbatim %}
+{% verbatim %}
 Redwood.controller("AdminCtrl", ["$rootScope", "$scope", "Admin", function($rootScope, $scope, ra) {
 	var Display = { //Display controller
 

--- a/expecon/templates/default_finish_page.html
+++ b/expecon/templates/default_finish_page.html
@@ -1,4 +1,4 @@
-{% autoescape off %}{% load verbatim %}{{ loadverbatim }}
+{% autoescape off %}
 <!DOCTYPE HTML>
 <html ng-app="Redwood">
 	<head>

--- a/expecon/templates/default_finish_page.js
+++ b/expecon/templates/default_finish_page.js
@@ -1,4 +1,4 @@
-{% load verbatim %}{% verbatim %}
+{% verbatim %}
 Redwood.controller("SubjectCtrl", ["$rootScope", "$scope", "RedwoodSubject", function($rootScope, $scope, rs) {
 	rs.on_load(function() {
 		$scope.pointsByPeriod = rs.subject[rs.user_id].points_by_period();

--- a/expecon/templates/default_page.css
+++ b/expecon/templates/default_page.css
@@ -1,4 +1,4 @@
-{% load verbatim %}{% verbatim %}
+{% verbatim %}
 body {
   padding-top: 10px;
 }

--- a/expecon/templates/default_page.html
+++ b/expecon/templates/default_page.html
@@ -1,4 +1,4 @@
-{% autoescape off %}{% load verbatim %}{{ loadverbatim }}
+{% autoescape off %}
 <!DOCTYPE HTML>
 <html ng-app="Redwood">
 	<head>

--- a/expecon/templates/default_page.js
+++ b/expecon/templates/default_page.js
@@ -1,4 +1,4 @@
-{% load verbatim %}{% verbatim %}Redwood.controller("SubjectCtrl", ["$rootScope", "$scope", "RedwoodSubject", function($rootScope, $scope, rs) {
+{% verbatim %}Redwood.controller("SubjectCtrl", ["$rootScope", "$scope", "RedwoodSubject", function($rootScope, $scope, rs) {
 	rs.on_load(function() { //called once the page has loaded for a new sub period
 		
 	});

--- a/expecon/templates/default_start_page.html
+++ b/expecon/templates/default_start_page.html
@@ -1,4 +1,4 @@
-{% autoescape off %}{% load verbatim %}{{ loadverbatim }}
+{% autoescape off %}
 <!DOCTYPE HTML>
 <html ng-app="Redwood">
 	<head>

--- a/expecon/templates/default_start_page.js
+++ b/expecon/templates/default_start_page.js
@@ -1,4 +1,4 @@
-{% load verbatim %}{% verbatim %}
+{% verbatim %}
 Redwood.controller("SubjectCtrl", ["$rootScope", "$scope", "RedwoodSubject", function($rootScope, $scope, rs) {
 	rs.on_load(function() {
 		

--- a/expecon/templates/default_wait_page.html
+++ b/expecon/templates/default_wait_page.html
@@ -1,4 +1,4 @@
-{% autoescape off %}{% load verbatim %}{{ loadverbatim }}
+{% autoescape off %}
 <!DOCTYPE HTML>
 <html ng-app="Redwood">
 	<head>

--- a/expecon/templates/default_wait_page.js
+++ b/expecon/templates/default_wait_page.js
@@ -1,4 +1,4 @@
-{% load verbatim %}{% verbatim %}
+{% verbatim %}
 Redwood.controller("SubjectCtrl", ["$rootScope", "$scope", "RedwoodSubject", function($rootScope, $scope, rs) {
 	rs.on_load(function() {
 		rs.next_period();

--- a/expecon/templates/session_payouts.html
+++ b/expecon/templates/session_payouts.html
@@ -1,4 +1,3 @@
-{% load verbatim %}
 <!DOCTYPE html>
 <html ng-app="Redwood">
 <head>


### PR DESCRIPTION
Django prior to 1.5 had no verbatim tag, so Redwood was using a custom implementation. Since Redwood has been upgraded to Django 1.7, we can take advantage of the more flexible built-in verbatim tag (nested verbatim blocks through named blocks!).

The built-in verbatim tag is loaded automatically. {% load verbatim %} is currently being used to load the custom verbatim implementation. Since many of the example experiments still use this, expecon/templates/templatetags/verbatim.py has not been deleted (yet).

Commit text:

- removed {% load verbatim %} from default experiment pages.
- however, the custom verbatim tag (expecon/templates/templatetags/verbatim.py) is still present for compatibility with experiments which still try to load it.