### PR TITLE
Added links to four subject pages from the experiment edit page

### DIFF
--- a/expecon/admin.py
+++ b/expecon/admin.py
@@ -31,10 +31,29 @@ class AlwaysChangedModelForm(ModelForm):
 class SessionInline(admin.StackedInline):
 	model = Session
 	extra = 0
-	readonly_fields = ('experiment','id')
+
+	fields = ('comments', 'subject_pages')
+	readonly_fields = ('experiment', 'id', 'subject_pages')
 	view_on_site = True
 	form = AlwaysChangedModelForm
-    
+
+	# A hacky way to get subject pages to show on admin page.
+	def subject_pages(self, obj):
+		if obj.id:
+			view = 'expecon.views.session_experiment'
+			template = '<a href="%s">Subject %d</a>'
+			links = []
+			for i in range(4):
+				subject = i + 1
+				url = reverse(view, args=(obj.id, subject))
+				link = template % (url, subject)
+				links.append(link)
+
+			return ', '.join(links)
+		else:
+			return None
+	subject_pages.allow_tags = True
+
 @admin.register(Experiment)
 class ExperimentAdmin(reversion.VersionAdmin):
 	inlines = (PageInline, SessionInline)

--- a/expecon/models.py
+++ b/expecon/models.py
@@ -4,6 +4,7 @@ from django.contrib.auth.models import User
 from django.utils.encoding import smart_str
 from django.template import loader
 from django.template import Template, Context
+from django.core.urlresolvers import reverse
 from fields import *
 import datetime
 import uuid
@@ -66,9 +67,8 @@ class Session(models.Model):
 	def __str__(self):
 		return smart_str('%d' % (self.id))
 	
-	@models.permalink	
 	def get_absolute_url(self):
-		return ('expecon.views.session_admin', (str(self.id),))
+		return reverse('expecon.views.session_admin', args=(self.id,))
 		
 class Page(models.Model):
 	experiment = models.ForeignKey(Experiment)


### PR DESCRIPTION
When writing experiments, it's often convenient to be able to open several subject pages at once without manually editing URLs. This change puts quick links to a few subject pages on the **Change Experiment** admin page.