### PR TITLE
Improved experiment upload predictability

### DIFF
--- a/expecon/templates/admin/expecon/experiment/change_form.html
+++ b/expecon/templates/admin/expecon/experiment/change_form.html
@@ -1,31 +1,74 @@
 {% extends "admin/expecon/change_form.html" %}
 {% load i18n %}
 
+{% block extrahead %}
+	{{block.super}}
+	<style type="text/css">
+		.experiment-edit-container {
+			border-top: 1px solid #CCC;
+			border-right: 1px solid #CCC;
+			border-left: 1px solid #CCC;
+		}
+
+		.experiment-edit-buttons {
+			margin: 0;
+			padding: 0;
+		}
+
+		.experiment-edit-buttons li {
+			float: left;
+			list-style: none;
+			border-right: 1px solid #CCC;
+			padding: 5px;
+		}
+
+		.experiment-edit-buttons li:last-child {
+			border: none;
+		}
+
+		.experiment-edit-buttons form input {
+			margin: 0;
+			padding: 0;
+		}
+
+	</style>
+	<script type="text/javascript">
+		$(function(){
+			$("#experiment-upload-chooser").on("change", function() {
+				console.log("upload dat shit");
+				$("#experiment-upload-form").submit();
+			});
+		});
+ 	</script>
+{% endblock %}
+
 {% block object-tools %}
 	{{ block.super }}
-	<div style="border-top: 1px solid #CCC; border-right: 1px solid #CCC; border-left: 1px solid #CCC;">
-		<ul style="margin: 0;">
-			<li style="list-style: none; float: left; border-right: 1px solid #CCC;">
-				<form">
+	<div class="experiment-edit-container">
+		<ul class="experiment-edit-buttons">
+			<li>
 				<form action="clone" method="POST">
 					{% csrf_token %}
 					<button class="btn" type="submit">Clone Experiment</button>
 				</form>
 			</li>
-			<li style="list-style: none; float: left; border-right: 1px solid #CCC;">
+			<li>
 				<form action="download" method="GET">
 					{% csrf_token %}
 					<button class="btn" type="submit">Download Experiment</button>
 				</form>
 			</li>
-			<li style="list-style: none; float: left;">
+			<li>
 				<form
+					id="experiment-upload-form"
 					action="upload"
 					method="POST"
 					enctype="multipart/form-data">
 					{% csrf_token %}
-					<input name="file" type="file" />
-					<button class="btn" type="submit">Upload Experiment</button>
+					<label>
+						Upload Experiment:
+						<input id="experiment-upload-chooser" name="file" type="file"/>
+					</label>
 				</form>
 			</li>
 		</ul>

--- a/expecon/urls.py
+++ b/expecon/urls.py
@@ -11,4 +11,5 @@ urlpatterns = patterns('expecon.views',
 	url(r'^admin/expecon/experiment/(?P<experiment>\d+)/clone$', 'clone_experiment'),
 	url(r'^admin/expecon/experiment/(?P<experiment>\d+)/download$', 'download_experiment'),
 	url(r'^admin/expecon/experiment/(?P<experiment>\d+)/upload$', 'upload_experiment'),
+	url(r'^admin/expecon/experiment/(add)/upload$', 'upload_experiment'),
 )

--- a/expecon/views.py
+++ b/expecon/views.py
@@ -157,7 +157,16 @@ def download_experiment(request, experiment):
 '''
 @login_required	
 def upload_experiment(request, experiment):
-	experiment = get_object_or_404(Experiment, pk=experiment)
+	if experiment == 'add':
+		# If this is a new experiment, create it
+		name = 'Experiment %d' % len(Experiment.objects.all())
+		experimenter = User.objects.first()
+		experiment = Experiment(name=name, experimenter=experimenter)
+		experiment.save()
+	else:
+		# If this experiment is already saved, retreive it
+		experiment = get_object_or_404(Experiment, pk=experiment)
+	
 	if request.method == 'POST':
 		if 'file' not in request.FILES:
 			return HttpResponse(status=405)


### PR DESCRIPTION
There are two things which make experiment uploading kind of unpredictable/unintuitive:

- It's not always obvious that the **upload experiment** button does requires that a file be chosen first.

- An error occurs when an experiment is uploaded before an experiment is saved for the first time (that is, when an experiment is being added).

To fix this, I've made these changes:

- Removed **upload experiment** button and made experiment upload occur as soon as a file is chosen

- Changed upload_experiment so that it creates and saves a new experiment with a placeholder name and the first user as the experimenter when uploading to an unsaved experiment.